### PR TITLE
Update rest-client version

### DIFF
--- a/fastlane-plugin-kobiton.gemspec
+++ b/fastlane-plugin-kobiton.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency('rest-client', '~> 1.8')
+  spec.add_dependency('rest-client', '~> 2.1')
   spec.add_dependency('json')
 
   spec.add_development_dependency('pry')


### PR DESCRIPTION
Fix issue on the `key not found: :ciphers` which needs a higher version of `rest-client` 2.x