### PR TITLE
Add optional name

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ This is a lightweight Fastlane plugin which uploads a given build to Kobiton pla
 
 This action does not have any output parameters yet, we are planning to define some in a future version.
 
-## Example
+## Usage
 
-Basic usage:
+### Basic usage:
 
 ```ruby
 platform :ios do
@@ -63,6 +63,19 @@ platform :ios do
   end
 end
 ```
+
+### Specify version name
+If you need the application version to have a different name in Kobiton than the application's name, you can specify it.
+```ruby
+kobiton(
+  name: "Release Candidate",
+  api_key: "01234567-89AB-CDEF-0123-456789AB",
+  username: "johndoe",
+  file: lane_context[SharedValues::IPA_OUTPUT_PATH],
+  app_id: 38007
+)
+```
+
 
 ## Run tests for this plugin
 

--- a/lib/fastlane/plugin/kobiton/actions/kobiton_action.rb
+++ b/lib/fastlane/plugin/kobiton/actions/kobiton_action.rb
@@ -58,7 +58,7 @@ module Fastlane
               UI.user_error!("App is taking a long time to process, could not rename.")
             end
 
-            break if (!status.nil? && status == 'OK')
+            break if !status.nil? && status == 'OK'
 
             sleep(2)
           end
@@ -232,7 +232,7 @@ module Fastlane
           return JSON.parse(app_version)['state']
         rescue RestClient::Exception => e
           if e.response.code == 404
-            return nil;
+            return nil
           end
 
           UI.user_error!("App status could not be received: #{e.response.code}, message: #{e.response.body}")

--- a/lib/fastlane/plugin/kobiton/actions/kobiton_action.rb
+++ b/lib/fastlane/plugin/kobiton/actions/kobiton_action.rb
@@ -195,9 +195,9 @@ module Fastlane
         }
 
         begin
-          RestClient.post("https://api.kobiton.com/v1/app/versions/#{version_id}/rename", {
+          RestClient.post("https://api.kobiton.com/v1/app/versions/#{version_id}/rename", JSON.generate({
             "newName" => name
-          }, headers)
+          }), headers)
 
 
         rescue RestClient::Exception => e

--- a/lib/fastlane/plugin/kobiton/actions/kobiton_action.rb
+++ b/lib/fastlane/plugin/kobiton/actions/kobiton_action.rb
@@ -47,10 +47,12 @@ module Fastlane
         name = params[:name]
 
         if !name.nil? && !name.empty?
-          UI.message("Updating version name to #{name}")
-          version_id = kobiton_notify['versionId']
+          UI.message("Waiting for build to process")
+          sleep(5) # Need to wait for Kobiton to process the build.
 
-          self.rename(version_id, name, authorization)
+          UI.message("Updating version name to #{name}")
+
+          self.rename(kobiton_notify['versionId'], name, authorization)
         end
       end
 
@@ -198,10 +200,8 @@ module Fastlane
           RestClient.post("https://api.kobiton.com/v1/app/versions/#{version_id}/rename", JSON.generate({
             "newName" => name
           }), headers)
-
-
         rescue RestClient::Exception => e
-          UI.user_error!("App name could not be assigned, status code: #{e.response.code}, message: #{e.response.body}")
+          UI.user_error!("App could not be renamed, status code: #{e.response.code}, message: #{e.response.body}")
         end
       end
     end

--- a/lib/fastlane/plugin/kobiton/version.rb
+++ b/lib/fastlane/plugin/kobiton/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Kobiton
-    VERSION = "0.2.3"
+    VERSION = "0.3.0"
   end
 end


### PR DESCRIPTION
This adds the ability to rename a build after it is uploaded by passing an optional `name` argument. 